### PR TITLE
Remove linting and variable definitions

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -84,14 +84,14 @@ function parse_expression(ps::ParseState)
         return error_unexpected(ps, ps.t.startbyte, ps.t)
     else
         ps.errored = true
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], Variable[], "Unknown error")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unknown error")
     end
 
     while !closer(ps) && !(ps.closer.precedence == DotOp && ismacro(ret))
         @catcherror ps ret = parse_compound(ps, ret)
     end
     if ps.closer.precedence != DotOp && closer(ps) && ret isa EXPR{LITERAL{Tokens.MACRO}}
-        ret = EXPR{MacroCall}(EXPR[ret], Variable[], "")
+        ret = EXPR{MacroCall}(EXPR[ret], "")
     end
 
     return ret
@@ -120,7 +120,7 @@ function parse_compound(ps::ParseState, ret)
     elseif ps.nt.kind == Tokens.DO
         ret = parse_do(ps, ret)
     elseif isajuxtaposition(ps, ret)
-        op = EXPR{OPERATOR{TimesOp,Tokens.STAR,false}}(EXPR[], 0, 1:0, Variable[], "")
+        op = EXPR{OPERATOR{TimesOp,Tokens.STAR,false}}(EXPR[], 0, 1:0, "")
         ret = parse_operator(ps, ret, op)
     elseif ps.nt.kind == Tokens.LPAREN && isemptyws(ps.ws)
         ret = @closer ps paren parse_call(ps, ret)
@@ -140,24 +140,24 @@ function parse_compound(ps::ParseState, ret)
     elseif (ret isa EXPR{IDENTIFIER} || (ret isa EXPR{BinarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{DotOp,Tokens.DOT,false}})) && (ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING)
         next(ps)
         @catcherror ps arg = parse_string_or_cmd(ps, ret)
-        ret = EXPR{x_Str}(EXPR[ret, arg], Variable[], "")
+        ret = EXPR{x_Str}(EXPR[ret, arg], "")
     # Suffix on x_str
     elseif ret isa EXPR{x_Str} && ps.nt.kind == Tokens.IDENTIFIER
         next(ps)
         arg = INSTANCE(ps)
-        push!(ret, EXPR{LITERAL{Tokens.STRING}}(EXPR[], arg.fullspan, arg.span, Variable[], arg.val))
+        push!(ret, EXPR{LITERAL{Tokens.STRING}}(EXPR[], arg.fullspan, arg.span, arg.val))
     elseif (ret isa EXPR{IDENTIFIER} || (ret isa EXPR{BinarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{DotOp,Tokens.DOT,false}})) && ps.nt.kind == Tokens.CMD
         next(ps)
         @catcherror ps arg = parse_string_or_cmd(ps, ret)
-        ret = EXPR{x_Cmd}(EXPR[ret, arg], Variable[], "")
+        ret = EXPR{x_Cmd}(EXPR[ret, arg], "")
     elseif ret isa EXPR{x_Cmd} && ps.nt.kind == Tokens.IDENTIFIER
         next(ps)
         arg = INSTANCE(ps)
-        push!(ret, EXPR{LITERAL{Tokens.STRING}}(EXPR[], arg.fullspan, 1:span(arg), Variable[], arg.val))
+        push!(ret, EXPR{LITERAL{Tokens.STRING}}(EXPR[], arg.fullspan, 1:span(arg), arg.val))
     elseif ret isa EXPR{UnarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{16,Tokens.PRIME,d1}} where d1
         # prime operator followed by an identifier has an implicit multiplication
         @catcherror ps nextarg = @precedence ps 11 parse_expression(ps)
-        ret = EXPR{BinaryOpCall}(EXPR[ret, EXPR{OPERATOR{TimesOp,Tokens.STAR,false}}(EXPR[], 0, 1:0, Variable[], ""), nextarg], Variable[], "")
+        ret = EXPR{BinaryOpCall}(EXPR[ret, EXPR{OPERATOR{TimesOp,Tokens.STAR,false}}(EXPR[], 0, 1:0, ""), nextarg], "")
 ################################################################################
 # Everything below here is an error
 ################################################################################
@@ -170,19 +170,19 @@ function parse_compound(ps::ParseState, ret)
             # TODO: Which operator? How do we get at the spelling
             0:0, [], "Unexpected operator"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, 0:-1, Variable[], "Unexpected operator")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, 0:-1, "Unexpected operator")
     elseif ps.nt.kind == Tokens.IDENTIFIER
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedIdentifier}(
             ps.nt.startbyte:ps.nt.endbyte, [], "Unexpected identifier"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, 0:-1, Variable[], "Unexpected identifier")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, 0:-1, "Unexpected identifier")
     else
         ps.errored = true
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, 0:-1, Variable[], "Unknown error")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, 0:-1, "Unknown error")
     end
     if ps.errored
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, 0:-1, Variable[], "Unknown error")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, 0:-1, "Unknown error")
     end
     return ret
 end
@@ -193,7 +193,7 @@ end
 Parses an expression starting with a `(`.
 """
 function parse_paren(ps::ParseState)
-    ret = EXPR{TupleH}(EXPR[INSTANCE(ps)], Variable[], "")
+    ret = EXPR{TupleH}(EXPR[INSTANCE(ps)], "")
     format_lbracket(ps)
 
     @catcherror ps @default ps @nocloser ps inwhere @closer ps paren parse_comma_sep(ps, ret, false, true)
@@ -201,7 +201,7 @@ function parse_paren(ps::ParseState)
     if length(ret.args) == 2 && !(ret.args[2] isa EXPR{UnarySyntaxOpCall} && ret.args[2].args[2] isa EXPR{OPERATOR{DddotOp,Tokens.DDDOT,false}})
 
         if ps.ws.kind != SemiColonWS || (length(ret.args) == 2 && ret.args[2] isa EXPR{Block})
-            ret = EXPR{InvisBrackets}(ret.args, Variable[], "")
+            ret = EXPR{InvisBrackets}(ret.args, "")
         end
     end
 
@@ -222,7 +222,7 @@ function parse(str::String, cont = false)
     ps = ParseState(str)
     x, ps = parse(ps, cont)
     if ps.errored
-        x = EXPR{ERROR}(EXPR[], 0, Variable[], "Unknown error")
+        x = EXPR{ERROR}(EXPR[], 0, "Unknown error")
     end
     return x
 end
@@ -239,15 +239,15 @@ function parse_doc(ps::ParseState)
         end
 
         ret = parse_expression(ps)
-        ret = EXPR{MacroCall}(EXPR[GlobalRefDOC, doc, ret], Variable[], "")
+        ret = EXPR{MacroCall}(EXPR[GlobalRefDOC, doc, ret], "")
     elseif ps.nt.kind == Tokens.IDENTIFIER && ps.nt.val == "doc" && (ps.nnt.kind == Tokens.STRING || ps.nnt.kind == Tokens.TRIPLE_STRING)
         next(ps)
         doc = INSTANCE(ps)
         next(ps)
         @catcherror ps arg = parse_string_or_cmd(ps, doc)
-        doc = EXPR{x_Str}(EXPR[doc, arg], Variable[], "")
+        doc = EXPR{x_Str}(EXPR[doc, arg], "")
         ret = parse_expression(ps)
-        ret = EXPR{MacroCall}(EXPR[GlobalRefDOC, doc, ret], Variable[], "")
+        ret = EXPR{MacroCall}(EXPR[GlobalRefDOC, doc, ret], "")
     else
         ret = parse_expression(ps)
     end
@@ -256,16 +256,16 @@ end
 
 function parse(ps::ParseState, cont = false)
     if ps.l.io.size == 0
-        return (cont ? EXPR{FileH}(EXPR[], 0, Variable[], "") : nothing), ps
+        return (cont ? EXPR{FileH}(EXPR[], 0, "") : nothing), ps
     end
     last_line = 0
     curr_line = 0
 
     if cont
-        top = EXPR{FileH}(EXPR[], 0, 1:0, Variable[], "")
+        top = EXPR{FileH}(EXPR[], 0, 1:0, "")
         if ps.nt.kind == Tokens.WHITESPACE || ps.nt.kind == Tokens.COMMENT
             next(ps)
-            push!(top, EXPR{LITERAL{nothing}}(EXPR[], ps.nt.startbyte, 1:ps.nt.startbyte, Variable[], "comments"))
+            push!(top, EXPR{LITERAL{nothing}}(EXPR[], ps.nt.startbyte, 1:ps.nt.startbyte, "comments"))
         end
 
         while !ps.done && !ps.errored
@@ -276,7 +276,7 @@ function parse(ps::ParseState, cont = false)
             if curr_line == last_line && last(top.args) isa EXPR{TopLevel}
                 push!(last(top.args), ret)
             elseif ps.ws.kind == SemiColonWS
-                push!(top, EXPR{TopLevel}(EXPR[ret], Variable[], ""))
+                push!(top, EXPR{TopLevel}(EXPR[ret], ""))
             else
                 push!(top, ret)
             end
@@ -285,12 +285,12 @@ function parse(ps::ParseState, cont = false)
     else
         if ps.nt.kind == Tokens.WHITESPACE || ps.nt.kind == Tokens.COMMENT
             next(ps)
-            top = EXPR{LITERAL{nothing}}(EXPR[], ps.nt.startbyte, 1:ps.nt.startbyte, Variable[], "comments")
+            top = EXPR{LITERAL{nothing}}(EXPR[], ps.nt.startbyte, 1:ps.nt.startbyte, "comments")
         else
             top = parse_doc(ps)
             last_line = ps.nt.startpos[1]
             if ps.ws.kind == SemiColonWS
-                top = EXPR{TopLevel}(EXPR[top], Variable[], "")
+                top = EXPR{TopLevel}(EXPR[top], "")
                 while ps.ws.kind == SemiColonWS && ps.nt.startpos[1] == last_line && ps.nt.kind != Tokens.ENDMARKER
                     ret = parse_doc(ps)
                     push!(top, ret)

--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -135,7 +135,6 @@ function parse_compound(ps::ParseState, ret)
     elseif isoperator(ps.nt)
         next(ps)
         op = INSTANCE(ps)
-        format_op(ps, precedence(ps.t))
         ret = parse_operator(ps, ret, op)
     elseif (ret isa EXPR{IDENTIFIER} || (ret isa EXPR{BinarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{DotOp,Tokens.DOT,false}})) && (ps.nt.kind == Tokens.STRING || ps.nt.kind == Tokens.TRIPLE_STRING)
         next(ps)
@@ -194,7 +193,6 @@ Parses an expression starting with a `(`.
 """
 function parse_paren(ps::ParseState)
     ret = EXPR{TupleH}(EXPR[INSTANCE(ps)], "")
-    format_lbracket(ps)
 
     @catcherror ps @default ps @nocloser ps inwhere @closer ps paren parse_comma_sep(ps, ret, false, true)
 
@@ -208,8 +206,6 @@ function parse_paren(ps::ParseState)
     # handle closing ')'
     next(ps)
     push!(ret, INSTANCE(ps))
-    format_rbracket(ps)
-
     return ret
 end
 

--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -218,7 +218,7 @@ function parse(str::String, cont = false)
     ps = ParseState(str)
     x, ps = parse(ps, cont)
     if ps.errored
-        x = EXPR{ERROR}(EXPR[], 0, "Unknown error")
+        x = EXPR{ERROR}(EXPR[], "Unknown error")
     end
     return x
 end
@@ -252,13 +252,13 @@ end
 
 function parse(ps::ParseState, cont = false)
     if ps.l.io.size == 0
-        return (cont ? EXPR{FileH}(EXPR[], 0, "") : nothing), ps
+        return (cont ? EXPR{FileH}(EXPR[], "") : nothing), ps
     end
     last_line = 0
     curr_line = 0
 
     if cont
-        top = EXPR{FileH}(EXPR[], 0, 1:0, "")
+        top = EXPR{FileH}(EXPR[], "")
         if ps.nt.kind == Tokens.WHITESPACE || ps.nt.kind == Tokens.COMMENT
             next(ps)
             push!(top, EXPR{LITERAL{nothing}}(EXPR[], ps.nt.startbyte, 1:ps.nt.startbyte, "comments"))

--- a/src/components/array.jl
+++ b/src/components/array.jl
@@ -15,7 +15,7 @@ function parse_array(ps::ParseState)
         push!(args, INSTANCE(ps))
         format_rbracket(ps)
 
-        return EXPR{Vect}(args, Variable[], "")
+        return EXPR{Vect}(args, "")
     else
         @catcherror ps first_arg = @default ps @nocloser ps newline @closer ps square @closer ps insquare @closer ps ws @closer ps wsop @closer ps comma parse_expression(ps)
 
@@ -26,9 +26,9 @@ function parse_array(ps::ParseState)
                 format_rbracket(ps)
 
                 if first_arg.args[1] isa EXPR{BinaryOpCall} && first_arg.args[2] isa EXPR{OPERATOR{AssignmentOp,Tokens.PAIR_ARROW,false}}
-                    return EXPR{DictComprehension}(EXPR[args[1], first_arg, INSTANCE(ps)], Variable[], "")
+                    return EXPR{DictComprehension}(EXPR[args[1], first_arg, INSTANCE(ps)], "")
                 else
-                    return EXPR{Comprehension}(EXPR[args[1], first_arg, INSTANCE(ps)], Variable[], "")
+                    return EXPR{Comprehension}(EXPR[args[1], first_arg, INSTANCE(ps)], "")
                 end
             elseif ps.ws.kind == SemiColonWS
                 next(ps)
@@ -36,17 +36,17 @@ function parse_array(ps::ParseState)
                 push!(args, INSTANCE(ps))
                 format_rbracket(ps)
 
-                return EXPR{Vcat}(args, Variable[], "")
+                return EXPR{Vcat}(args, "")
             else
                 next(ps)
                 push!(args, first_arg)
                 push!(args, INSTANCE(ps))
                 format_rbracket(ps)
 
-                ret = EXPR{Vect}(args, Variable[], "")
+                ret = EXPR{Vect}(args, "")
             end
         elseif ps.nt.kind == Tokens.COMMA
-            ret = EXPR{Vect}(args, Variable[], "")
+            ret = EXPR{Vect}(args, "")
             push!(ret, first_arg)
             next(ps)
             push!(ret, INSTANCE(ps))
@@ -56,7 +56,7 @@ function parse_array(ps::ParseState)
 
 
             if last(ret.args) isa EXPR{Parameters}
-                ret = EXPR{Vcat}(ret.args, Variable[], "")
+                ret = EXPR{Vcat}(ret.args, "")
                 unshift!(ret, pop!(ret))
                 # if isempty(last(ret.args).args)
                 #     pop!(ret.args)
@@ -68,7 +68,7 @@ function parse_array(ps::ParseState)
 
             return ret
         elseif ps.ws.kind == NewLineWS
-            ret = EXPR{Vcat}(args, Variable[], "")
+            ret = EXPR{Vcat}(args, "")
             push!(ret, first_arg)
             while ps.nt.kind != Tokens.RSQUARE
                 @catcherror ps a = @default ps @closer ps square parse_expression(ps)
@@ -80,14 +80,14 @@ function parse_array(ps::ParseState)
 
             return ret
         elseif ps.ws.kind == WS || ps.ws.kind == SemiColonWS
-            first_row = EXPR{Hcat}(EXPR[first_arg], Variable[], "")
+            first_row = EXPR{Hcat}(EXPR[first_arg], "")
             while ps.nt.kind != Tokens.RSQUARE && ps.ws.kind != NewLineWS && ps.ws.kind != SemiColonWS
                 @catcherror ps a = @default ps @closer ps square @closer ps ws @closer ps wsop parse_expression(ps)
                 push!(first_row, a)
             end
             if ps.nt.kind == Tokens.RSQUARE && ps.ws.kind != SemiColonWS
                 if length(first_row.args) == 1
-                    first_row = EXPR{VCAT}(first_row.args, Variable[], "")
+                    first_row = EXPR{VCAT}(first_row.args, "")
                 end
                 next(ps)
                 push!(first_row, INSTANCE(ps))
@@ -97,12 +97,12 @@ function parse_array(ps::ParseState)
                 if length(first_row.args) == 1
                     first_row = first_row.args[1]
                 else
-                    first_row = EXPR{Row}(first_row.args, Variable[], "")
+                    first_row = EXPR{Row}(first_row.args, "")
                 end
-                ret = EXPR{Vcat}(EXPR[args[1], first_row], Variable[], "")
+                ret = EXPR{Vcat}(EXPR[args[1], first_row], "")
                 while ps.nt.kind != Tokens.RSQUARE
                     @catcherror ps first_arg = @default ps @closer ps square @closer ps ws @closer ps wsop parse_expression(ps)
-                    push!(ret, EXPR{Row}(EXPR[first_arg], Variable[], ""))
+                    push!(ret, EXPR{Row}(EXPR[first_arg], ""))
                     while ps.nt.kind != Tokens.RSQUARE && ps.ws.kind != NewLineWS && ps.ws.kind != SemiColonWS
                         @catcherror ps a = @default ps @closer ps square @closer ps ws @closer ps wsop parse_expression(ps)
                         push!(last(ret.args), a)
@@ -119,7 +119,7 @@ function parse_array(ps::ParseState)
             end
         else
             ps.errored = true
-            ret = EXPR{ERROR}(EXPR[INSTANCE(ps)], Variable[], "Unknown error")
+            ret = EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unknown error")
         end
     end
     return ret
@@ -139,7 +139,7 @@ function parse_ref(ps::ParseState, ret)
 end
 
 function _parse_ref(ret, ref::EXPR{Vect})
-    ret = EXPR{Ref}(EXPR[ret], Variable[], "")
+    ret = EXPR{Ref}(EXPR[ret], "")
     for a in ref.args
         push!(ret, a)
     end
@@ -147,7 +147,7 @@ function _parse_ref(ret, ref::EXPR{Vect})
 end
 
 function _parse_ref(ret, ref::EXPR{Hcat})
-    ret = EXPR{TypedHcat}(EXPR[ret], Variable[], "")
+    ret = EXPR{TypedHcat}(EXPR[ret], "")
     for a in ref.args
         push!(ret, a)
     end
@@ -155,7 +155,7 @@ function _parse_ref(ret, ref::EXPR{Hcat})
 end
 
 function _parse_ref(ret, ref::EXPR{Vcat})
-    ret = EXPR{TypedVcat}(EXPR[ret], Variable[], "")
+    ret = EXPR{TypedVcat}(EXPR[ret], "")
     for a in ref.args
         push!(ret, a)
     end
@@ -163,7 +163,7 @@ function _parse_ref(ret, ref::EXPR{Vcat})
 end
 
 function _parse_ref(ret, ref)
-    ret = EXPR{TypedComprehension}(EXPR[ret], Variable[], "")
+    ret = EXPR{TypedComprehension}(EXPR[ret], "")
     for a in ref.args
         push!(ret, a)
     end

--- a/src/components/array.jl
+++ b/src/components/array.jl
@@ -8,12 +8,10 @@ Having hit '[' return either:
 """
 function parse_array(ps::ParseState)
     args = EXPR[INSTANCE(ps)]
-    format_lbracket(ps)
 
     if ps.nt.kind == Tokens.RSQUARE
         next(ps)
         push!(args, INSTANCE(ps))
-        format_rbracket(ps)
 
         return EXPR{Vect}(args, "")
     else
@@ -23,7 +21,6 @@ function parse_array(ps::ParseState)
             if first_arg isa EXPR{Generator} || first_arg isa EXPR{Flatten}
                 next(ps)
                 push!(args, INSTANCE(ps))
-                format_rbracket(ps)
 
                 if first_arg.args[1] isa EXPR{BinaryOpCall} && first_arg.args[2] isa EXPR{OPERATOR{AssignmentOp,Tokens.PAIR_ARROW,false}}
                     return EXPR{DictComprehension}(EXPR[args[1], first_arg, INSTANCE(ps)], "")
@@ -34,14 +31,12 @@ function parse_array(ps::ParseState)
                 next(ps)
                 push!(args, first_arg)
                 push!(args, INSTANCE(ps))
-                format_rbracket(ps)
 
                 return EXPR{Vcat}(args, "")
             else
                 next(ps)
                 push!(args, first_arg)
                 push!(args, INSTANCE(ps))
-                format_rbracket(ps)
 
                 ret = EXPR{Vect}(args, "")
             end
@@ -50,7 +45,6 @@ function parse_array(ps::ParseState)
             push!(ret, first_arg)
             next(ps)
             push!(ret, INSTANCE(ps))
-            format_comma(ps)
             @catcherror ps @default ps @closer ps square parse_comma_sep(ps, ret, false)
 
 
@@ -64,7 +58,6 @@ function parse_array(ps::ParseState)
             end
             next(ps)
             push!(ret, INSTANCE(ps))
-            format_rbracket(ps)
 
             return ret
         elseif ps.ws.kind == NewLineWS
@@ -76,7 +69,6 @@ function parse_array(ps::ParseState)
             end
             next(ps)
             push!(ret, INSTANCE(ps))
-            format_rbracket(ps)
 
             return ret
         elseif ps.ws.kind == WS || ps.ws.kind == SemiColonWS

--- a/src/components/curly.jl
+++ b/src/components/curly.jl
@@ -7,7 +7,7 @@ seperated list.
 function parse_curly(ps::ParseState, ret)
     next(ps)
     format_lbracket(ps)
-    ret = EXPR{Curly}(EXPR[ret, INSTANCE(ps)], Variable[], "")
+    ret = EXPR{Curly}(EXPR[ret, INSTANCE(ps)], "")
 
     @catcherror ps  @default ps @nocloser ps inwhere @closer ps brace parse_comma_sep(ps, ret, true, false, false)
     next(ps)
@@ -18,7 +18,7 @@ end
 
 function parse_cell1d(ps::ParseState)
     format_lbracket(ps)
-    ret = EXPR{Cell1d}(EXPR[INSTANCE(ps)], Variable[], "")
+    ret = EXPR{Cell1d}(EXPR[INSTANCE(ps)], "")
     @catcherror ps @default ps @closer ps brace parse_comma_sep(ps, ret, true, false, false)
     next(ps)
     push!(ret, INSTANCE(ps))

--- a/src/components/curly.jl
+++ b/src/components/curly.jl
@@ -6,22 +6,18 @@ seperated list.
 """
 function parse_curly(ps::ParseState, ret)
     next(ps)
-    format_lbracket(ps)
     ret = EXPR{Curly}(EXPR[ret, INSTANCE(ps)], "")
 
     @catcherror ps  @default ps @nocloser ps inwhere @closer ps brace parse_comma_sep(ps, ret, true, false, false)
     next(ps)
-    format_rbracket(ps)
     push!(ret, INSTANCE(ps))
     return ret
 end
 
 function parse_cell1d(ps::ParseState)
-    format_lbracket(ps)
     ret = EXPR{Cell1d}(EXPR[INSTANCE(ps)], "")
     @catcherror ps @default ps @closer ps brace parse_comma_sep(ps, ret, true, false, false)
     next(ps)
     push!(ret, INSTANCE(ps))
-    format_rbracket(ps)
     return ret
 end

--- a/src/components/do.jl
+++ b/src/components/do.jl
@@ -2,7 +2,6 @@ function parse_do(ps::ParseState, ret)
     # Parsing
     next(ps)
     kw = INSTANCE(ps)
-    format_kw(ps)
 
     args = EXPR{TupleH}(EXPR[], "")
     @default ps @closer ps comma @closer ps block while !closer(ps)
@@ -11,7 +10,6 @@ function parse_do(ps::ParseState, ret)
         push!(args, a)
         if ps.nt.kind == Tokens.COMMA
             next(ps)
-            format_comma(ps)
             push!(args, INSTANCE(ps))
         end
     end

--- a/src/components/do.jl
+++ b/src/components/do.jl
@@ -4,10 +4,9 @@ function parse_do(ps::ParseState, ret)
     kw = INSTANCE(ps)
     format_kw(ps)
 
-    args = EXPR{TupleH}(EXPR[], Variable[], "")
+    args = EXPR{TupleH}(EXPR[], "")
     @default ps @closer ps comma @closer ps block while !closer(ps)
         @catcherror ps a = parse_expression(ps)
-        push!(args.defs, Variable(Symbol(_arg_id(a).val), get_t(a), args))
 
         push!(args, a)
         if ps.nt.kind == Tokens.COMMA
@@ -16,11 +15,11 @@ function parse_do(ps::ParseState, ret)
             push!(args, INSTANCE(ps))
         end
     end
-    block = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)
 
     # Construction
-    ret = EXPR{Do}(EXPR[ret, kw], Variable[], "")
+    ret = EXPR{Do}(EXPR[ret, kw], "")
     push!(ret, args)
     push!(ret, block)
     next(ps)

--- a/src/components/functions.jl
+++ b/src/components/functions.jl
@@ -9,9 +9,9 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.FUNCTION}})
         op = OPERATOR(ps)
         next(ps)
         if issyntaxunarycall(op)
-            sig = EXPR{UnarySyntaxOpCall}(EXPR[op, INSTANCE(ps)], Variable[], "")
+            sig = EXPR{UnarySyntaxOpCall}(EXPR[op, INSTANCE(ps)], "")
         else
-            sig = EXPR{Call}(EXPR[op, INSTANCE(ps)], Variable[], "")
+            sig = EXPR{Call}(EXPR[op, INSTANCE(ps)], "")
         end
         @catcherror ps @default ps @closer ps paren parse_comma_sep(ps, sig)
         next(ps)
@@ -28,12 +28,10 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.FUNCTION}})
     end
 
     if sig isa EXPR{InvisBrackets} && !(sig.args[2] isa EXPR{TupleH})
-        sig = EXPR{TupleH}(sig.args, Variable[], "")
+        sig = EXPR{TupleH}(sig.args, "")
     end
 
-    _get_sig_defs!(sig)
-
-    block = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps @scope ps Scope{Tokens.FUNCTION} parse_block(ps, block)
 
 
@@ -50,13 +48,11 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.FUNCTION}})
 
     next(ps)
 
-    ret = EXPR{FunctionDef}(EXPR[kw], Variable[], "")
+    ret = EXPR{FunctionDef}(EXPR[kw], "")
     for a in args
         push!(ret, a)
     end
     push!(ret, INSTANCE(ps))
-
-    ret.defs = [Variable(Expr(_get_fname(sig)), :Function, ret)]
     return ret
 end
 
@@ -67,37 +63,37 @@ Parses a function call. Expects to start before the opening parentheses and is p
 """
 function parse_call(ps::ParseState, ret::EXPR{OPERATOR{PlusOp,Tokens.EX_OR,false}})
     arg = @precedence ps 20 parse_expression(ps)
-    ret = EXPR{UnarySyntaxOpCall}(EXPR[ret, arg], Variable[], "")
+    ret = EXPR{UnarySyntaxOpCall}(EXPR[ret, arg], "")
     return ret
 end
 function parse_call(ps::ParseState, ret::EXPR{OPERATOR{DeclarationOp,Tokens.DECLARATION,false}})
     arg = @precedence ps 20 parse_expression(ps)
-    ret = EXPR{UnarySyntaxOpCall}(EXPR[ret, arg], Variable[], "")
+    ret = EXPR{UnarySyntaxOpCall}(EXPR[ret, arg], "")
     return ret
 end
 function parse_call(ps::ParseState, ret::EXPR{OP}) where OP <: OPERATOR{TimesOp,Tokens.AND}
     arg = @precedence ps 20 parse_expression(ps)
-    ret = EXPR{UnarySyntaxOpCall}(EXPR[ret, arg], Variable[], "")
+    ret = EXPR{UnarySyntaxOpCall}(EXPR[ret, arg], "")
     return ret
 end
 function parse_call(ps::ParseState, ret::EXPR{OPERATOR{ComparisonOp,Tokens.ISSUBTYPE,false}})
     arg = @precedence ps 13 parse_expression(ps)
-    ret = EXPR{Call}(EXPR[ret; arg.args], Variable[], "")
+    ret = EXPR{Call}(EXPR[ret; arg.args], "")
     return ret
 end
 
 function parse_call(ps::ParseState, ret::EXPR{OPERATOR{ComparisonOp,Tokens.ISSUPERTYPE,false}})
     arg = @precedence ps 13 parse_expression(ps)
-    ret = EXPR{Call}(EXPR[ret; arg.args], Variable[], "")
+    ret = EXPR{Call}(EXPR[ret; arg.args], "")
     return ret
 end
 
 function parse_call(ps::ParseState, ret::EXPR{OP}) where OP <: OPERATOR{20,Tokens.NOT}
     arg = @precedence ps 13 parse_expression(ps)
     if arg isa EXPR{TupleH}
-        ret = EXPR{Call}(EXPR[ret; arg.args], Variable[], "")
+        ret = EXPR{Call}(EXPR[ret; arg.args], "")
     else
-        ret = EXPR{UnaryOpCall}(EXPR[ret, arg], Variable[], "")
+        ret = EXPR{UnaryOpCall}(EXPR[ret, arg], "")
     end
     return ret
 end
@@ -105,9 +101,9 @@ end
 function parse_call(ps::ParseState, ret::EXPR{OP}) where OP <: OPERATOR{PlusOp,Tokens.PLUS}
     arg = @precedence ps 13 parse_expression(ps)
     if arg isa EXPR{TupleH}
-        ret = EXPR{Call}(EXPR[ret; arg.args], Variable[], "")
+        ret = EXPR{Call}(EXPR[ret; arg.args], "")
     else
-        ret = EXPR{UnaryOpCall}(EXPR[ret, arg], Variable[], "")
+        ret = EXPR{UnaryOpCall}(EXPR[ret, arg], "")
     end
     return ret
 end
@@ -115,16 +111,16 @@ end
 function parse_call(ps::ParseState, ret::EXPR{OP}) where OP <: OPERATOR{PlusOp,Tokens.MINUS}
     arg = @precedence ps 13 parse_expression(ps)
     if arg isa EXPR{TupleH}
-        ret = EXPR{Call}(EXPR[ret; arg.args], Variable[], "")
+        ret = EXPR{Call}(EXPR[ret; arg.args], "")
     else
-        ret = EXPR{UnaryOpCall}(EXPR[ret, arg], Variable[], "")
+        ret = EXPR{UnaryOpCall}(EXPR[ret, arg], "")
     end
     return ret
 end
 
 function parse_call(ps::ParseState, ret)
     next(ps)
-    ret = EXPR{Call}(EXPR[ret, INSTANCE(ps)], Variable[], "")
+    ret = EXPR{Call}(EXPR[ret, INSTANCE(ps)], "")
     format_lbracket(ps)
     @default ps @closer ps paren parse_comma_sep(ps, ret)
     next(ps)
@@ -140,7 +136,7 @@ function parse_comma_sep(ps::ParseState, ret::EXPR, kw = true, block = false, fo
         a = parse_expression(ps)
 
         if kw && !ps.closer.brace && a isa EXPR{BinarySyntaxOpCall} && a.args[2] isa EXPR{OPERATOR{AssignmentOp,Tokens.EQ,false}}
-            a = EXPR{Kw}(a.args, Variable[], "")
+            a = EXPR{Kw}(a.args, "")
         end
         push!(ret, a)
         if ps.nt.kind == Tokens.COMMA
@@ -159,10 +155,7 @@ function parse_comma_sep(ps::ParseState, ret::EXPR, kw = true, block = false, fo
 
     if ps.ws.kind == SemiColonWS
         if block && !(ret isa EXPR{TupleH} && length(ret.args) > 2)
-            body = EXPR{Block}(EXPR[pop!(ret)], Variable[], "")
-            # if last(body.args) isa EXPR{BinarySyntaxOpCall} && last(body.args).args[2] isa EXPR{OP} where OP <: OPERATOR{AssignmentOp,Tokens.EQ}
-            #     _track_assignment(ps, last(body.args).args[1], last(body.args).args[3], last(body.args).defs)
-            # end
+            body = EXPR{Block}(EXPR[pop!(ret)], "")
             @nocloser ps newline @closer ps comma while @nocloser ps semicolon !closer(ps)
                 @catcherror ps a = parse_expression(ps)
                 push!(body, a)
@@ -172,11 +165,11 @@ function parse_comma_sep(ps::ParseState, ret::EXPR, kw = true, block = false, fo
         else
             kw = true
             ps.nt.kind == Tokens.RPAREN && return
-            paras = EXPR{Parameters}(EXPR[], Variable[], "")
+            paras = EXPR{Parameters}(EXPR[], "")
             @nocloser ps inwhere @nocloser ps newline @nocloser ps semicolon @closer ps comma while !closer(ps)
                 @catcherror ps a = parse_expression(ps)
                 if kw && !ps.closer.brace && a isa EXPR{BinarySyntaxOpCall} && a.args[2] isa EXPR{OPERATOR{AssignmentOp,Tokens.EQ,false}}
-                    a = EXPR{Kw}(a.args, Variable[], "")
+                    a = EXPR{Kw}(a.args, "")
                 end
                 push!(paras, a)
                 if ps.nt.kind == Tokens.COMMA
@@ -191,41 +184,6 @@ function parse_comma_sep(ps::ParseState, ret::EXPR, kw = true, block = false, fo
 end
 
 
-function _get_sig_defs!(sig1)
-    params = _get_fparams(sig1)
-    sig1.defs = Variable[Variable(p, :DataType, sig1) for p in params]
-
-    sig = sig1
-    while sig isa EXPR{BinarySyntaxOpCall} && (sig.args[2] isa EXPR{OPERATOR{DeclarationOp,Tokens.DECLARATION,false}} || sig.args[2] isa EXPR{OPERATOR{WhereOp,Tokens.WHERE,false}})
-        if sig.args[2] isa EXPR{OPERATOR{WhereOp,Tokens.WHERE,false}}
-            haswhere = true
-        end
-        sig = sig.args[1]
-    end
-
-    # Add variable def for struct call overloads
-    fname = _get_fname(sig)
-    if fname isa EXPR{InvisBrackets} && fname.args[2] isa EXPR{BinarySyntaxOpCall} && fname.args[2].args[2] isa EXPR{OPERATOR{DeclarationOp,Tokens.DECLARATION,false}}
-        push!(sig1.defs, Variable(get_id(fname.args[2]).val, get_t(fname.args[2]), sig1))
-    end
-
-    for i = 2:length(sig.args)
-        arg = sig.args[i]
-        if arg isa EXPR{Parameters}
-            for arg1 in arg.args
-                a = _arg_id(arg1)
-                !(a isa EXPR{IDENTIFIER}) && continue
-                t = get_t(arg1)
-                push!(sig1.defs, Variable(Symbol(a.val), t, sig1))
-            end
-        elseif !(arg isa EXPR{P} where P <: PUNCTUATION)
-            a = _arg_id(arg)
-            !(a isa EXPR{IDENTIFIER}) && continue
-            t = get_t(arg)
-            push!(sig1.defs, Variable(Symbol(a.val), t, sig1))
-        end
-    end
-end
 
 # NEEDS FIX
 _arg_id(x) = x

--- a/src/components/functions.jl
+++ b/src/components/functions.jl
@@ -1,7 +1,6 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.FUNCTION}})
     # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     # signature
 
     if isoperator(ps.nt.kind) && ps.nt.kind != Tokens.EX_OR && ps.nnt.kind == Tokens.LPAREN
@@ -121,11 +120,9 @@ end
 function parse_call(ps::ParseState, ret)
     next(ps)
     ret = EXPR{Call}(EXPR[ret, INSTANCE(ps)], "")
-    format_lbracket(ps)
     @default ps @closer ps paren parse_comma_sep(ps, ret)
     next(ps)
     push!(ret, INSTANCE(ps))
-    format_rbracket(ps)
     return ret
 end
 
@@ -142,11 +139,6 @@ function parse_comma_sep(ps::ParseState, ret::EXPR, kw = true, block = false, fo
         if ps.nt.kind == Tokens.COMMA
             next(ps)
             push!(ret, INSTANCE(ps))
-            if formatcomma
-                format_comma(ps)
-            else
-                format_no_rws(ps)
-            end
         end
         if ps.ws.kind == SemiColonWS
             break
@@ -175,7 +167,6 @@ function parse_comma_sep(ps::ParseState, ret::EXPR, kw = true, block = false, fo
                 if ps.nt.kind == Tokens.COMMA
                     next(ps)
                     push!(paras, INSTANCE(ps))
-                    format_comma(ps)
                 end
             end
             push!(ret, paras)

--- a/src/components/genericblocks.jl
+++ b/src/components/genericblocks.jl
@@ -2,11 +2,11 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.BEGIN}})
     # Parsing
     kw = INSTANCE(ps)
     format_kw(ps)
-    arg = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    arg = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps arg = @default ps parse_block(ps, arg, Tokens.Kind[Tokens.END], true)
 
     next(ps)
-    return EXPR{Begin}(EXPR[kw; arg; INSTANCE(ps)], Variable[], "")
+    return EXPR{Begin}(EXPR[kw; arg; INSTANCE(ps)], "")
 end
 
 

--- a/src/components/genericblocks.jl
+++ b/src/components/genericblocks.jl
@@ -1,7 +1,6 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.BEGIN}})
     # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     arg = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps arg = @default ps parse_block(ps, arg, Tokens.Kind[Tokens.END], true)
 

--- a/src/components/if.jl
+++ b/src/components/if.jl
@@ -11,16 +11,16 @@ function parse_if(ps::ParseState, nested = false)
     format_kw(ps)
     @catcherror ps cond = @default ps @closer ps block @closer ps ws parse_expression(ps)
 
-    ifblock = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    ifblock = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps @closer ps ifelse parse_block(ps, ifblock, Tokens.Kind[Tokens.END, Tokens.ELSE, Tokens.ELSEIF])
 
     if nested
-        ret = EXPR{If}(EXPR[cond, ifblock], Variable[], "")
+        ret = EXPR{If}(EXPR[cond, ifblock], "")
     else
-        ret = EXPR{If}(EXPR[kw, cond, ifblock], Variable[], "")
+        ret = EXPR{If}(EXPR[kw, cond, ifblock], "")
     end
 
-    elseblock = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    elseblock = EXPR{Block}(EXPR[], 0, 1:0, "")
     if ps.nt.kind == Tokens.ELSEIF
         next(ps)
         push!(ret, INSTANCE(ps))

--- a/src/components/if.jl
+++ b/src/components/if.jl
@@ -8,7 +8,6 @@ Parse an `if` block.
 function parse_if(ps::ParseState, nested = false)
     # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     @catcherror ps cond = @default ps @closer ps block @closer ps ws parse_expression(ps)
 
     ifblock = EXPR{Block}(EXPR[], 0, 1:0, "")

--- a/src/components/let.jl
+++ b/src/components/let.jl
@@ -1,7 +1,6 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.LET}})
     # Parsing
     ret = EXPR{Let}(EXPR[INSTANCE(ps)], "")
-    format_kw(ps)
 
     @default ps @closer ps comma @closer ps block while !closer(ps)
         @catcherror ps a = parse_expression(ps)
@@ -9,7 +8,6 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.LET}})
         if ps.nt.kind == Tokens.COMMA
             next(ps)
             push!(ret, INSTANCE(ps))
-            format_comma(ps)
         end
     end
     block = EXPR{Block}(EXPR[], 0, 1:0, "")

--- a/src/components/let.jl
+++ b/src/components/let.jl
@@ -1,6 +1,6 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.LET}})
     # Parsing
-    ret = EXPR{Let}(EXPR[INSTANCE(ps)], Variable[], "")
+    ret = EXPR{Let}(EXPR[INSTANCE(ps)], "")
     format_kw(ps)
 
     @default ps @closer ps comma @closer ps block while !closer(ps)
@@ -12,7 +12,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.LET}})
             format_comma(ps)
         end
     end
-    block = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)
 
     # Construction

--- a/src/components/loops.jl
+++ b/src/components/loops.jl
@@ -3,10 +3,10 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.FOR}})
     kw = INSTANCE(ps)
     format_kw(ps)
     @catcherror ps ranges = @default ps parse_ranges(ps)
-    block = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)
     next(ps)
-    ret = EXPR{For}(EXPR[kw, ranges, block, INSTANCE(ps)], Variable[], "")
+    ret = EXPR{For}(EXPR[kw, ranges, block, INSTANCE(ps)], "")
 
     return ret
 end
@@ -15,33 +15,20 @@ end
 function parse_ranges(ps::ParseState)
     defs = []
     arg = @closer ps range @closer ps comma @closer ps ws parse_expression(ps)
-    _track_range_assignment(ps, arg)
     if ps.nt.kind == Tokens.COMMA
-        arg = EXPR{Block}(EXPR[arg], Variable[], "")
+        arg = EXPR{Block}(EXPR[arg], "")
         while ps.nt.kind == Tokens.COMMA
             next(ps)
             push!(arg, INSTANCE(ps))
             format_comma(ps)
 
             @catcherror ps nextarg = @closer ps comma @closer ps ws parse_expression(ps)
-            _track_range_assignment(ps, nextarg)
             push!(arg, nextarg)
         end
     end
     return arg
 end
 
-function _track_range_assignment(ps, x) end
-function _track_range_assignment(ps, x::EXPR{BinaryOpCall})
-    if (x.args[2] isa EXPR{OPERATOR{ComparisonOp,Tokens.IN,false}} || x.args[2] isa EXPR{OPERATOR{ComparisonOp,Tokens.ELEMENT_OF,false}})
-        append!(x.defs, _track_assignment(ps::ParseState, x.args[1], x.args[3]))
-    end
-end
-function _track_range_assignment(ps, x::EXPR{BinarySyntaxOpCall})
-    if x.args[2] isa EXPR{OPERATOR{AssignmentOp,Tokens.EQ,false}}
-        append!(x.defs, _track_assignment(ps::ParseState, x.args[1], x.args[3]))
-    end
-end
 
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.WHILE}})
@@ -49,21 +36,21 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.WHILE}})
     kw = INSTANCE(ps)
     format_kw(ps)
     @catcherror ps cond = @default ps @closer ps ws parse_expression(ps)
-    block = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)
     next(ps)
 
-    ret = EXPR{While}(EXPR[kw, cond, block, INSTANCE(ps)], Variable[], "")
+    ret = EXPR{While}(EXPR[kw, cond, block, INSTANCE(ps)], "")
 
     return ret
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.BREAK}})
-    return EXPR{Break}(EXPR[INSTANCE(ps)], Variable[], "")
+    return EXPR{Break}(EXPR[INSTANCE(ps)], "")
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.CONTINUE}})
-    return EXPR{Continue}(EXPR[INSTANCE(ps)], Variable[], "")
+    return EXPR{Continue}(EXPR[INSTANCE(ps)], "")
 end
 
 
@@ -76,14 +63,14 @@ Comprehensions are parsed as SQUAREs containing a generator.
 function parse_generator(ps::ParseState, ret)
     next(ps)
     kw = INSTANCE(ps)
-    ret = EXPR{Generator}(EXPR[ret, kw], Variable[], "")
+    ret = EXPR{Generator}(EXPR[ret, kw], "")
     @catcherror ps ranges = @closer ps paren @closer ps square parse_ranges(ps)
 
     if ps.nt.kind == Tokens.IF
         if ranges isa EXPR{Block}
-            ranges = EXPR{Filter}(EXPR[ranges.args...], Variable[], "")
+            ranges = EXPR{Filter}(EXPR[ranges.args...], "")
         else
-            ranges = EXPR{Filter}(EXPR[ranges], Variable[], "")
+            ranges = EXPR{Filter}(EXPR[ranges], "")
         end
         next(ps)
         unshift!(ranges, INSTANCE(ps))
@@ -100,7 +87,7 @@ function parse_generator(ps::ParseState, ret)
 
     # This should reverse order of iterators
     if ret.args[1] isa EXPR{Generator} || ret.args[1] isa EXPR{Flatten}
-        ret = EXPR{Flatten}([ret], Variable[], "")
+        ret = EXPR{Flatten}([ret], "")
     end
 
     return ret

--- a/src/components/loops.jl
+++ b/src/components/loops.jl
@@ -1,7 +1,6 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.FOR}})
     # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     @catcherror ps ranges = @default ps parse_ranges(ps)
     block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)
@@ -20,7 +19,6 @@ function parse_ranges(ps::ParseState)
         while ps.nt.kind == Tokens.COMMA
             next(ps)
             push!(arg, INSTANCE(ps))
-            format_comma(ps)
 
             @catcherror ps nextarg = @closer ps comma @closer ps ws parse_expression(ps)
             push!(arg, nextarg)
@@ -34,7 +32,6 @@ end
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.WHILE}})
     # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     @catcherror ps cond = @default ps @closer ps ws parse_expression(ps)
     block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)

--- a/src/components/macros.jl
+++ b/src/components/macros.jl
@@ -1,6 +1,5 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.MACRO}})
     kw = INSTANCE(ps)
-    format_kw(ps)
     if ps.nt.kind == Tokens.IDENTIFIER
         next(ps)
         sig = INSTANCE(ps)

--- a/src/components/macros.jl
+++ b/src/components/macros.jl
@@ -9,13 +9,11 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.MACRO}})
         @catcherror ps sig = @closer ps block @closer ps ws parse_expression(ps)
     end
 
-    _get_sig_defs!(sig)
-    block = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)
 
     next(ps)
-    ret = EXPR{Macro}(EXPR[kw, sig, block, INSTANCE(ps)], Variable[], "")
-    ret.defs =  [Variable(Symbol("@", Expr(_get_fname(sig))), :Macro, ret)]
+    ret = EXPR{Macro}(EXPR[kw, sig, block, INSTANCE(ps)], "")
     return ret
 end
 
@@ -27,21 +25,21 @@ Parses a macro call. Expects to start on the `@`.
 function parse_macrocall(ps::ParseState)
     next(ps)
     mname = IDENTIFIER(ps)
-    mname = EXPR{IDENTIFIER}(EXPR[], 1+mname.fullspan, 1:(last(mname.span)+1), Variable[], string("@", ps.t.val))
+    mname = EXPR{IDENTIFIER}(EXPR[], 1+mname.fullspan, 1:(last(mname.span)+1), string("@", ps.t.val))
     # Handle cases with @ at start of dotted expressions
     if ps.nt.kind == Tokens.DOT && isemptyws(ps.ws)
         while ps.nt.kind == Tokens.DOT
             next(ps)
             op = INSTANCE(ps)
             if ps.nt.kind != Tokens.IDENTIFIER
-                return EXPR{ERROR}(EXPR[], 0, 1:0, Variable[], "Invalid macro name")
+                return EXPR{ERROR}(EXPR[], 0, 1:0, "Invalid macro name")
             end
             next(ps)
             nextarg = INSTANCE(ps)
-            mname = EXPR{BinarySyntaxOpCall}(EXPR[mname, op, Quotenode(nextarg)], Variable[], "")
+            mname = EXPR{BinarySyntaxOpCall}(EXPR[mname, op, Quotenode(nextarg)], "")
         end
     end
-    ret = EXPR{MacroCall}(EXPR[mname], Variable[], "")
+    ret = EXPR{MacroCall}(EXPR[mname], "")
 
     if ps.nt.kind == Tokens.COMMA
         return ret

--- a/src/components/modules.jl
+++ b/src/components/modules.jl
@@ -8,7 +8,6 @@ parse_kw(ps::ParseState, ::Type{Val{Tokens.BAREMODULE}}) = parse_module(ps)
 function parse_module(ps::ParseState)
     # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     if ps.nt.kind == Tokens.IDENTIFIER
         next(ps)
         arg = INSTANCE(ps)
@@ -101,7 +100,6 @@ function parse_imports(ps::ParseState)
     kwt = kw isa EXPR{KEYWORD{Tokens.IMPORT}} ? Import :
           kw isa EXPR{KEYWORD{Tokens.IMPORTALL}} ? ImportAll :
           Using
-    format_kw(ps)
     tk = ps.t.kind
 
     arg = parse_dot_mod(ps)
@@ -140,7 +138,6 @@ end
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.EXPORT}})
     # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     ret = EXPR{Export}(EXPR[kw; parse_dot_mod(ps)], "")
 
     while ps.nt.kind == Tokens.COMMA

--- a/src/components/modules.jl
+++ b/src/components/modules.jl
@@ -57,7 +57,7 @@ function parse_dot_mod(ps::ParseState, is_colon = false)
             next(ps)
             next(ps)
             a = INSTANCE(ps)
-            push!(args, EXPR{IDENTIFIER}(EXPR[], a.fullspan + 1, 1:(span(a) + 1), Variable[], string("@", a.val)))
+            push!(args, EXPR{IDENTIFIER}(EXPR[], a.fullspan + 1, 1:(span(a) + 1), string("@", a.val)))
         elseif ps.nt.kind == Tokens.LPAREN
             next(ps)
             a = EXPR{InvisBrackets}(EXPR[INSTANCE(ps)], "")

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -346,7 +346,6 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{WhereOp,Tok
             if ps.nt.kind == Tokens.COMMA
                 next(ps)
                 push!(ret, INSTANCE(ps))
-                format_no_rws(ps)
             end
         end
         next(ps)

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -185,7 +185,7 @@ function parse_unary(ps::ParseState, op::EXPR{OPERATOR{P,K,dot}}) where {P, K, d
     if issyntaxunarycall(op)
         ret = EXPR{UnarySyntaxOpCall}(EXPR[op, arg], "")
     else
-        ret = EXPR{Call}(EXPR[op, arg], "")
+        ret = EXPR{UnaryOpCall}(EXPR[op, arg], "")
     end
     return ret
 end

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -183,9 +183,9 @@ function parse_unary(ps::ParseState, op::EXPR{OPERATOR{P,K,dot}}) where {P, K, d
     @catcherror ps arg = @precedence ps prec parse_expression(ps)
 
     if issyntaxunarycall(op)
-        ret = EXPR{UnarySyntaxOpCall}(EXPR[op, arg], Variable[], "")
+        ret = EXPR{UnarySyntaxOpCall}(EXPR[op, arg], "")
     else
-        ret = EXPR{Call}(EXPR[op, arg], Variable[], "")
+        ret = EXPR{Call}(EXPR[op, arg], "")
     end
     return ret
 end
@@ -198,19 +198,18 @@ function parse_unary(ps::ParseState, op::EXPR{OPERATOR{ColonOp,Tokens.COLON,fals
         # Parsing
         next(ps)
         arg = INSTANCE(ps)
-        return EXPR{Quotenode}(EXPR[op, arg], Variable[], "")
+        return EXPR{Quotenode}(EXPR[op, arg], "")
     elseif closer(ps)
         return op
     else
         # Parsing
         @catcherror ps arg = @precedence ps 20 parse_expression(ps)
-        return EXPR{Quote}(EXPR[op, arg], Variable[], "")
+        return EXPR{Quote}(EXPR[op, arg], "")
     end
 end
 
 # Parse assignments
 function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{AssignmentOp,Tokens.EQ,false}})
-    is_func_call(ret) && _get_sig_defs!(ret)
     # Parsing
     @catcherror ps nextarg = @precedence ps AssignmentOp - LtoR(AssignmentOp) parse_expression(ps)
 
@@ -218,20 +217,12 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{AssignmentO
         # Construction
         # NOTE: prior to v"0.6.0-dev.2360" (PR #20076), there was an issue w/ scheme parser
         if VERSION > v"0.6.0-dev.2360" || (length(ret.args) > 1 && !(ret.args[2] isa EXPR{OPERATOR{DeclarationOp,Tokens.DECLARATION,false}}) && ps.closer.precedence != 0)
-            nextarg = EXPR{Block}(EXPR[nextarg],  Variable[], "")
+            nextarg = EXPR{Block}(EXPR[nextarg], "")
         end
-
-        ret1 = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], Variable[], "")
-        ret1.defs = [Variable(Expr(_get_fname(ret)), :Function, ret1)]
+        ret1 = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], "")
         return ret1
     else
-        defs = ps.trackscope ? _track_assignment(ps, ret, nextarg) : Variable[]
-        if nextarg isa EXPR{BinarySyntaxOpCall} && nextarg.args[2] isa EXPR{OPERATOR{AssignmentOp,Tokens.EQ,false}}
-            append!(defs, nextarg.defs)
-            empty!(nextarg.defs)
-        end
-        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], Variable[], "")
-        ret.defs = defs
+        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], "")
         return ret
     end
 end
@@ -244,7 +235,7 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{Conditional
     @catcherror ps nextarg2 = @closer ps comma @precedence ps 0 parse_expression(ps)
 
     # Construction
-    ret = EXPR{ConditionalOpCall}(EXPR[ret, op, nextarg, op2, nextarg2], Variable[], "")
+    ret = EXPR{ConditionalOpCall}(EXPR[ret, op, nextarg, op2, nextarg2], "")
     return ret
 end
 
@@ -258,13 +249,13 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{ComparisonO
         push!(ret, op)
         push!(ret, nextarg)
     elseif ret isa EXPR{BinaryOpCall} && precedence(ret.args[2]) == ComparisonOp
-        ret = EXPR{Comparison}(EXPR[ret.args[1], ret.args[2], ret.args[3], op, nextarg], Variable[], "")
+        ret = EXPR{Comparison}(EXPR[ret.args[1], ret.args[2], ret.args[3], op, nextarg], "")
     elseif ret isa EXPR{BinarySyntaxOpCall} && (ret.args[2] isa EXPR{OPERATOR{ComparisonOp,Tokens.ISSUBTYPE,false}} || ret.args[2] isa EXPR{OPERATOR{ComparisonOp,Tokens.ISSUPERTYPE,false}})
-        ret = EXPR{Comparison}(EXPR[ret.args[1], ret.args[2], ret.args[3], op, nextarg], Variable[], "")
+        ret = EXPR{Comparison}(EXPR[ret.args[1], ret.args[2], ret.args[3], op, nextarg], "")
     elseif (op isa EXPR{OPERATOR{ComparisonOp,Tokens.ISSUBTYPE,false}} || op isa EXPR{OPERATOR{ComparisonOp,Tokens.ISSUPERTYPE,false}})
-        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], Variable[], "")
+        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], "")
     else
-        ret = EXPR{BinaryOpCall}(EXPR[ret, op, nextarg], Variable[], "")
+        ret = EXPR{BinaryOpCall}(EXPR[ret, op, nextarg], "")
     end
     return ret
 end
@@ -276,11 +267,11 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{ColonOp,Tok
 
     # Construction
     if ret isa EXPR{BinarySyntaxOpCall} && ret.args[2] isa EXPR{OPERATOR{ColonOp,Tokens.COLON,false}} && length(ret.args) == 3
-        ret = EXPR{ColonOpCall}(ret.args, Variable[], "")
+        ret = EXPR{ColonOpCall}(ret.args, "")
         push!(ret, op)
         push!(ret, nextarg)
     else
-        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], Variable[], "")
+        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], "")
     end
     return ret
 end
@@ -309,7 +300,7 @@ end
 function parse_chain_operator(ps::ParseState, ret::EXPR{BinaryOpCall}, op::EXPR{OPERATOR{P,K,false}}) where {P, K}
     if ret.args[2] isa EXPR{OPERATOR{P,K,false}} && span(ret.args[2]) > 0
         @catcherror ps nextarg = @precedence ps P - LtoR(P) parse_expression(ps)
-        ret = EXPR{ChainOpCall}(ret.args, Variable[], "")
+        ret = EXPR{ChainOpCall}(ret.args, "")
         push!(ret, op)
         push!(ret, nextarg)
     else
@@ -328,14 +319,14 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{PowerOp,K,d
     # NEEDS FIX
     if ret isa EXPR{UnaryOpCall}
         if false
-            xx = EXPR{InvisBrackets}([ret], Variable[], "")
-            nextarg = EXPR{BinaryOpCall}(EXPR[op, xx, nextarg], Variable[], "")
+            xx = EXPR{InvisBrackets}([ret], "")
+            nextarg = EXPR{BinaryOpCall}(EXPR[op, xx, nextarg], "")
         else
-            nextarg = EXPR{BinaryOpCall}(EXPR[ret.args[2], op, nextarg], Variable[], "")
+            nextarg = EXPR{BinaryOpCall}(EXPR[ret.args[2], op, nextarg], "")
         end
-        ret = EXPR{UnaryOpCall}(EXPR[ret.args[1], nextarg], Variable[], "")
+        ret = EXPR{UnaryOpCall}(EXPR[ret.args[1], nextarg], "")
     else
-        ret = EXPR{BinaryOpCall}(EXPR[ret, op, nextarg], Variable[], "")
+        ret = EXPR{BinaryOpCall}(EXPR[ret, op, nextarg], "")
     end
     return ret
 end
@@ -344,7 +335,7 @@ end
 # parse where
 function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{WhereOp,Tokens.WHERE,false}})
     # Parsing
-    ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op], Variable[], "")
+    ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op], "")
     # Parsing
     if ps.nt.kind == Tokens.LBRACE
         next(ps)
@@ -374,8 +365,8 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{DotOp,Token
     # Parsing
     if ps.nt.kind == Tokens.LPAREN
         @catcherror ps sig = @default ps @closer ps paren parse_call(ps, ret)
-        args = EXPR{TupleH}(sig.args[2:end], Variable[], "")
-        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, args], Variable[], "")
+        args = EXPR{TupleH}(sig.args[2:end], "")
+        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, args], "")
         return ret
     elseif iskw(ps.nt) || ps.nt.kind == Tokens.IN || ps.nt.kind == Tokens.ISA || ps.nt.kind == Tokens.WHERE
         next(ps)
@@ -386,7 +377,7 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{DotOp,Token
         op2 = INSTANCE(ps)
         if ps.nt.kind == Tokens.LPAREN
             @catcherror ps nextarg = @precedence ps DotOp - LtoR(DotOp) parse_expression(ps)
-            nextarg = EXPR{Quote}(EXPR[op2, nextarg], Variable[], "")
+            nextarg = EXPR{Quote}(EXPR[op2, nextarg], "")
         else
             @catcherror ps nextarg = @precedence ps DotOp - LtoR(DotOp) parse_unary(ps, op2)
         end
@@ -401,26 +392,26 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{DotOp,Token
     # Construction
     # NEEDS FIX
     if nextarg isa EXPR{IDENTIFIER} || nextarg isa EXPR{Vect} || nextarg isa EXPR{UnarySyntaxOpCall} && nextarg.args[1] isa EXPR{OPERATOR{PlusOp,Tokens.EX_OR,false}}
-        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, Quotenode(nextarg)], Variable[], "")
+        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, Quotenode(nextarg)], "")
     elseif nextarg isa EXPR{MacroCall}
-        mname = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, Quotenode(nextarg.args[1])], Variable[], "")
-        ret = EXPR{MacroCall}(EXPR[mname], Variable[], "")
+        mname = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, Quotenode(nextarg.args[1])], "")
+        ret = EXPR{MacroCall}(EXPR[mname], "")
         for i = 2:length(nextarg.args)
             push!(ret, nextarg.args[i])
         end
     else
-        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], Variable[], "")
+        ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, nextarg], "")
     end
     return ret
 end
 
 
 function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{DddotOp,Tokens.DDDOT,false}})
-    return EXPR{UnarySyntaxOpCall}(EXPR[ret, op], Variable[], "")
+    return EXPR{UnarySyntaxOpCall}(EXPR[ret, op], "")
 end
 
 function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{16,Tokens.PRIME,dot}}) where dot
-    return EXPR{UnarySyntaxOpCall}(EXPR[ret, op], Variable[], "")
+    return EXPR{UnarySyntaxOpCall}(EXPR[ret, op], "")
 end
 
 function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{P,Tokens.ANON_FUNC,false}}) where {P}
@@ -428,12 +419,8 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{P,Tokens.AN
     @catcherror ps arg = @closer ps comma @precedence ps 0 parse_expression(ps)
 
     # Construction
-    if ret isa EXPR{TupleH}
-        _get_sig_defs!(ret)
-    else
-        push!(ret.defs, Variable(Expr(get_id(ret)), get_t(ret), ret))
-    end
-    ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, EXPR{Block}(EXPR[arg], Variable[], "")], Variable[], "")
+    
+    ret = EXPR{BinarySyntaxOpCall}(EXPR[ret, op, EXPR{Block}(EXPR[arg], "")], "")
 
     return ret
 end
@@ -444,9 +431,9 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR{OPERATOR{P,K,dot}}) 
 
     # Construction
     if issyntaxcall(op)
-        ret = EXPR{BinarySyntaxOpCall}([ret, op, nextarg], Variable[], "")
+        ret = EXPR{BinarySyntaxOpCall}([ret, op, nextarg], "")
     else
-        ret = EXPR{BinaryOpCall}([ret, op, nextarg], Variable[], "")
+        ret = EXPR{BinaryOpCall}([ret, op, nextarg], "")
     end
     return ret
 end

--- a/src/components/prefixkw.jl
+++ b/src/components/prefixkw.jl
@@ -42,23 +42,23 @@ end
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.ELSE}})
     ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), "else")
     ps.errored = true
-    return EXPR{ERROR}(EXPR[], 0, "incorrect use of else")
+    return EXPR{ERROR}(EXPR[], "incorrect use of else")
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.ELSEIF}})
     ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), "elseif")
     ps.errored = true
-    return EXPR{ERROR}(EXPR[], 0, "incorrect use of else")
+    return EXPR{ERROR}(EXPR[], "incorrect use of else")
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.CATCH}})
     ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), "catch")
     ps.errored = true
-    return EXPR{ERROR}(EXPR[], 0, "incorrect use of catch")
+    return EXPR{ERROR}(EXPR[], "incorrect use of catch")
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.FINALLY}})
     ret = IDENTIFIER(ps.nt.startbyte - ps.t.startbyte, :finally)
     ps.errored = true
-    return EXPR{ERROR}(EXPR[], 0, "incorrect use of finally")
+    return EXPR{ERROR}(EXPR[], "incorrect use of finally")
 end

--- a/src/components/prefixkw.jl
+++ b/src/components/prefixkw.jl
@@ -1,56 +1,32 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.CONST}})
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     @catcherror ps arg = @default ps parse_expression(ps)
 
-    # Construction
     ret = EXPR{Const}(EXPR[kw, arg], "")
-
     return ret
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.GLOBAL}})
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     @catcherror ps arg = parse_expression(ps)
 
-    # Construction
-    # if arg isa EXPR{TupleH} && first(arg.punctuation) isa PUNCTUATION{Tokens.COMMA}
-    #     ret = EXPR(Global, [kw, arg.args...], ps.nt.startbyte - startbyte, arg.punctuation)
-    # else
     ret = EXPR{Global}(EXPR[kw, arg], "")
-    # end
-
     return ret
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.LOCAL}})
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     @catcherror ps arg = @default ps parse_expression(ps)
 
-    # Construction
-    # if arg isa EXPR && arg.head == TUPLE && first(arg.punctuation) isa PUNCTUATION{Tokens.COMMA}
-    #     ret = EXPR(Local, [kw, arg.args...], ps.nt.startbyte - startbyte, arg.punctuation)
-    # else
     ret = EXPR{Local}(EXPR[kw, arg], "")
-    # end
-
     return ret
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.RETURN}})
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     @catcherror ps args = @default ps closer(ps) ? NOTHING : parse_expression(ps)
 
-    # Construction
     ret = EXPR{Return}(EXPR[kw, args], "")
-
     return ret
 end
 

--- a/src/components/prefixkw.jl
+++ b/src/components/prefixkw.jl
@@ -5,7 +5,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.CONST}})
     @catcherror ps arg = @default ps parse_expression(ps)
 
     # Construction
-    ret = EXPR{Const}(EXPR[kw, arg], Variable[], "")
+    ret = EXPR{Const}(EXPR[kw, arg], "")
 
     return ret
 end
@@ -20,7 +20,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.GLOBAL}})
     # if arg isa EXPR{TupleH} && first(arg.punctuation) isa PUNCTUATION{Tokens.COMMA}
     #     ret = EXPR(Global, [kw, arg.args...], ps.nt.startbyte - startbyte, arg.punctuation)
     # else
-    ret = EXPR{Global}(EXPR[kw, arg], Variable[], "")
+    ret = EXPR{Global}(EXPR[kw, arg], "")
     # end
 
     return ret
@@ -36,7 +36,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.LOCAL}})
     # if arg isa EXPR && arg.head == TUPLE && first(arg.punctuation) isa PUNCTUATION{Tokens.COMMA}
     #     ret = EXPR(Local, [kw, arg.args...], ps.nt.startbyte - startbyte, arg.punctuation)
     # else
-    ret = EXPR{Local}(EXPR[kw, arg], Variable[], "")
+    ret = EXPR{Local}(EXPR[kw, arg], "")
     # end
 
     return ret
@@ -49,40 +49,40 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.RETURN}})
     @catcherror ps args = @default ps closer(ps) ? NOTHING : parse_expression(ps)
 
     # Construction
-    ret = EXPR{Return}(EXPR[kw, args], Variable[], "")
+    ret = EXPR{Return}(EXPR[kw, args], "")
 
     return ret
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.END}})
-    ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), Variable[], "end")
+    ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), "end")
     if !ps.closer.square
         ps.errored = true
-        return EXPR{ERROR}(EXPR[], Variable[], "incorrect use of end")
+        return EXPR{ERROR}(EXPR[], "incorrect use of end")
     end
     return ret
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.ELSE}})
-    ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), Variable[], "else")
+    ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), "else")
     ps.errored = true
-    return EXPR{ERROR}(EXPR[], 0, Variable[], "incorrect use of else")
+    return EXPR{ERROR}(EXPR[], 0, "incorrect use of else")
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.ELSEIF}})
-    ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), Variable[], "elseif")
+    ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), "elseif")
     ps.errored = true
-    return EXPR{ERROR}(EXPR[], 0, Variable[], "incorrect use of else")
+    return EXPR{ERROR}(EXPR[], 0, "incorrect use of else")
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.CATCH}})
-    ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), Variable[], "catch")
+    ret = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1 + (0:ps.t.endbyte-ps.t.startbyte), "catch")
     ps.errored = true
-    return EXPR{ERROR}(EXPR[], 0, Variable[], "incorrect use of catch")
+    return EXPR{ERROR}(EXPR[], 0, "incorrect use of catch")
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.FINALLY}})
     ret = IDENTIFIER(ps.nt.startbyte - ps.t.startbyte, :finally)
     ps.errored = true
-    return EXPR{ERROR}(EXPR[], 0, Variable[], "incorrect use of finally")
+    return EXPR{ERROR}(EXPR[], 0, "incorrect use of finally")
 end

--- a/src/components/quote.jl
+++ b/src/components/quote.jl
@@ -2,12 +2,12 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.QUOTE}})
     # Parsing
     kw = INSTANCE(ps)
     format_kw(ps)
-    arg = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    arg = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, arg)
     next(ps)
 
     # Construction
-    ret = EXPR{Quote}(EXPR[kw, arg, INSTANCE(ps)], Variable[], "")
+    ret = EXPR{Quote}(EXPR[kw, arg, INSTANCE(ps)], "")
 
     return ret
 end

--- a/src/components/quote.jl
+++ b/src/components/quote.jl
@@ -1,13 +1,9 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.QUOTE}})
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     arg = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, arg)
     next(ps)
 
-    # Construction
     ret = EXPR{Quote}(EXPR[kw, arg, INSTANCE(ps)], "")
-
     return ret
 end

--- a/src/components/try.jl
+++ b/src/components/try.jl
@@ -1,7 +1,5 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.TRY}})
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     ret = EXPR{Try}(EXPR[kw], "")
 
     tryblock = EXPR{Block}(EXPR[], 0, 1:0, "")

--- a/src/components/try.jl
+++ b/src/components/try.jl
@@ -2,9 +2,9 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.TRY}})
     # Parsing
     kw = INSTANCE(ps)
     format_kw(ps)
-    ret = EXPR{Try}(EXPR[kw], Variable[], "")
+    ret = EXPR{Try}(EXPR[kw], "")
 
-    tryblock = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    tryblock = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps @closer ps trycatch parse_block(ps, tryblock,)
     push!(ret, tryblock)
 
@@ -12,7 +12,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.TRY}})
     if ps.nt.kind == Tokens.END
         next(ps)
         push!(ret, FALSE)
-        push!(ret, EXPR{Block}(EXPR[], 0, 1:0, Variable[], ""))
+        push!(ret, EXPR{Block}(EXPR[], 0, 1:0, ""))
         push!(ret, INSTANCE(ps))
         return ret
     end
@@ -24,7 +24,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.TRY}})
         if ps.nt.kind == Tokens.FINALLY || ps.nt.kind == Tokens.END
             push!(ret, INSTANCE(ps))
             caught = FALSE
-            catchblock = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+            catchblock = EXPR{Block}(EXPR[], 0, 1:0, "")
         else
             start_col = ps.t.startpos[2] + 4
             push!(ret, INSTANCE(ps))
@@ -33,18 +33,16 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.TRY}})
             else
                 @catcherror ps caught = @default ps @closer ps ws @closer ps trycatch parse_expression(ps)
             end
-            catchblock = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+            catchblock = EXPR{Block}(EXPR[], 0, 1:0, "")
             @catcherror ps @default ps @closer ps trycatch parse_block(ps, catchblock)
             if !(caught isa EXPR{IDENTIFIER} || caught == FALSE)
                 unshift!(catchblock, caught)
                 caught = FALSE
-            elseif caught isa EXPR{IDENTIFIER}
-                push!(caught.defs, Variable(Expr(caught), :Any, caught))
             end
         end
     else
         caught = FALSE
-        catchblock = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+        catchblock = EXPR{Block}(EXPR[], 0, 1:0, "")
     end
     push!(ret, caught)
     push!(ret, catchblock)
@@ -56,7 +54,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.TRY}})
         end
         next(ps)
         push!(ret, INSTANCE(ps))
-        finallyblock = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+        finallyblock = EXPR{Block}(EXPR[], 0, 1:0, "")
         @catcherror ps parse_block(ps, finallyblock)
         push!(ret, finallyblock)
     end

--- a/src/components/tuples.jl
+++ b/src/components/tuples.jl
@@ -5,10 +5,8 @@
 tuple.
 """
 function parse_tuple(ps::ParseState, ret)
-    # Parsing
     next(ps)
     op = INSTANCE(ps)
-    format_comma(ps)
 
     if isassignment(ps.nt) && ps.nt.kind != Tokens.APPROX
         if ret isa EXPR{TupleH}
@@ -17,14 +15,14 @@ function parse_tuple(ps::ParseState, ret)
             ret =  EXPR{TupleH}(EXPR[ret, op], "")
         end
     elseif closer(ps)
-        if ret isa EXPR{TupleH}  #(length(ret.punctuation) == 0 || !(first(ret.args) isa PUNCTUATION{Tokens.LPAREN}))
+        if ret isa EXPR{TupleH}
             push!(ret, op)
         else
             ret = EXPR{TupleH}(EXPR[ret, op], "")
         end
     else
         @catcherror ps nextarg = @closer ps tuple parse_expression(ps)
-        if ret isa EXPR{TupleH} && (!(first(ret.args) isa EXPR{PUNCTUATION{Tokens.LPAREN}})) # && length(ret.punctuation) == 0 ||
+        if ret isa EXPR{TupleH} && (!(first(ret.args) isa EXPR{PUNCTUATION{Tokens.LPAREN}}))
             push!(ret, op)
             push!(ret, nextarg)
         else

--- a/src/components/tuples.jl
+++ b/src/components/tuples.jl
@@ -14,13 +14,13 @@ function parse_tuple(ps::ParseState, ret)
         if ret isa EXPR{TupleH}
             push!(ret, op)
         else
-            ret =  EXPR{TupleH}(EXPR[ret, op], Variable[], "")
+            ret =  EXPR{TupleH}(EXPR[ret, op], "")
         end
     elseif closer(ps)
         if ret isa EXPR{TupleH}  #(length(ret.punctuation) == 0 || !(first(ret.args) isa PUNCTUATION{Tokens.LPAREN}))
             push!(ret, op)
         else
-            ret = EXPR{TupleH}(EXPR[ret, op], Variable[], "")
+            ret = EXPR{TupleH}(EXPR[ret, op], "")
         end
     else
         @catcherror ps nextarg = @closer ps tuple parse_expression(ps)
@@ -28,7 +28,7 @@ function parse_tuple(ps::ParseState, ret)
             push!(ret, op)
             push!(ret, nextarg)
         else
-            ret = EXPR{TupleH}(EXPR[ret, op, nextarg], Variable[], "")
+            ret = EXPR{TupleH}(EXPR[ret, op, nextarg], "")
         end
     end
     return ret

--- a/src/components/types.jl
+++ b/src/components/types.jl
@@ -12,16 +12,15 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.ABSTRACT}})
 
         # Construction
         next(ps)
-        ret = EXPR{Abstract}(EXPR[kw1, kw2, sig, INSTANCE(ps)], Variable[], "")
+        ret = EXPR{Abstract}(EXPR[kw1, kw2, sig, INSTANCE(ps)], "")
     else
         # Parsing
         kw = INSTANCE(ps)
         @catcherror ps sig = @default ps parse_expression(ps)
 
         # Construction
-        ret = EXPR{Abstract}(EXPR[kw, sig], Variable[], "")
+        ret = EXPR{Abstract}(EXPR[kw, sig], "")
     end
-    ret.defs = [Variable(Expr(get_id(sig)), :abstract, ret)]
     return ret
 end
 
@@ -34,8 +33,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.BITSTYPE}})
     @catcherror ps arg2 = @default ps parse_expression(ps)
 
     # Construction
-    ret = EXPR{Bitstype}(EXPR[kw, arg1, arg2], Variable[], "")
-    ret.defs = [Variable(Expr(get_id(arg2)), :bitstype, ret)]
+    ret = EXPR{Bitstype}(EXPR[kw, arg1, arg2], "")
 
     return ret
 end
@@ -53,11 +51,10 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.PRIMITIVE}})
 
         # Construction
         next(ps)
-        ret = EXPR{Primitive}(EXPR[kw1, kw2, sig, arg, INSTANCE(ps)], Variable[], "")
+        ret = EXPR{Primitive}(EXPR[kw1, kw2, sig, arg, INSTANCE(ps)], "")
 
-        ret.defs = [Variable(Expr(get_id(sig)), :bitstype, ret)]
     else
-        ret = EXPR{IDENTIFIER}(EXPR[], Variable[], "primitive")
+        ret = EXPR{IDENTIFIER}(EXPR[], "primitive")
     end
     return ret
 end
@@ -70,7 +67,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.TYPEALIAS}})
     @catcherror ps arg1 = @closer ps ws @closer ps wsop parse_expression(ps)
     @catcherror ps arg2 = parse_expression(ps)
 
-    return EXPR{TypeAlias}(EXPR[kw, arg1, arg2], Variable[], "")
+    return EXPR{TypeAlias}(EXPR[kw, arg1, arg2], "")
 end
 
 parse_kw(ps::ParseState, ::Type{Val{Tokens.TYPE}}) = parse_struct(ps, TRUE)
@@ -98,14 +95,13 @@ function parse_struct(ps::ParseState, mutable)
     kw = INSTANCE(ps)
     format_kw(ps)
     @catcherror ps sig = @default ps @closer ps block @closer ps ws parse_expression(ps)
-    block = EXPR{Block}(EXPR[], 0, 1:0, Variable[], "")
+    block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)
 
     # Construction
     T = mutable == TRUE ? Tokens.TYPE : Tokens.IMMUTABLE
     next(ps)
-    ret = EXPR{mutable == TRUE ? Mutable : Struct}(EXPR[kw, sig, block, INSTANCE(ps)], Variable[], "")
-    ret.defs = [Variable(Expr(get_id(sig)), Expr(mutable) ? :mutable : :immutable, ret)]
+    ret = EXPR{mutable == TRUE ? Mutable : Struct}(EXPR[kw, sig, block, INSTANCE(ps)], "")
 
     return ret
 end

--- a/src/components/types.jl
+++ b/src/components/types.jl
@@ -1,58 +1,43 @@
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.ABSTRACT}})
     # Switch for v0.6 compatability
     if ps.nt.kind == Tokens.TYPE
-        # Parsing
         kw1 = INSTANCE(ps)
-        format_kw(ps)
         next(ps)
         kw2 = INSTANCE(ps)
-        format_kw(ps)
 
         @catcherror ps sig = @default ps @closer ps block parse_expression(ps)
 
-        # Construction
         next(ps)
         ret = EXPR{Abstract}(EXPR[kw1, kw2, sig, INSTANCE(ps)], "")
     else
-        # Parsing
         kw = INSTANCE(ps)
         @catcherror ps sig = @default ps parse_expression(ps)
 
-        # Construction
         ret = EXPR{Abstract}(EXPR[kw, sig], "")
     end
     return ret
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.BITSTYPE}})
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
 
     @catcherror ps arg1 = @default ps @closer ps ws @closer ps wsop parse_expression(ps)
     @catcherror ps arg2 = @default ps parse_expression(ps)
 
-    # Construction
     ret = EXPR{Bitstype}(EXPR[kw, arg1, arg2], "")
-
     return ret
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.PRIMITIVE}})
     if ps.nt.kind == Tokens.TYPE
-        # Parsing
         kw1 = INSTANCE(ps)
-        format_kw(ps)
         next(ps)
         kw2 = INSTANCE(ps)
-        format_kw(ps)
         @catcherror ps sig = @default ps @closer ps ws @closer ps wsop parse_expression(ps)
         @catcherror ps arg = @default ps @closer ps block parse_expression(ps)
 
-        # Construction
         next(ps)
         ret = EXPR{Primitive}(EXPR[kw1, kw2, sig, arg, INSTANCE(ps)], "")
-
     else
         ret = EXPR{IDENTIFIER}(EXPR[], "primitive")
     end
@@ -60,9 +45,7 @@ function parse_kw(ps::ParseState, ::Type{Val{Tokens.PRIMITIVE}})
 end
 
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.TYPEALIAS}})
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
 
     @catcherror ps arg1 = @closer ps ws @closer ps wsop parse_expression(ps)
     @catcherror ps arg2 = parse_expression(ps)
@@ -79,7 +62,6 @@ parse_kw(ps::ParseState, ::Type{Val{Tokens.STRUCT}}) = parse_struct(ps, FALSE)
 function parse_kw(ps::ParseState, ::Type{Val{Tokens.MUTABLE}})
     if ps.nt.kind == Tokens.STRUCT
         kw = INSTANCE(ps)
-        format_kw(ps)
         next(ps)
         @catcherror ps ret = parse_struct(ps, TRUE)
         unshift!(ret, kw)
@@ -91,9 +73,7 @@ end
 
 
 function parse_struct(ps::ParseState, mutable)
-    # Parsing
     kw = INSTANCE(ps)
-    format_kw(ps)
     @catcherror ps sig = @default ps @closer ps block @closer ps ws parse_expression(ps)
     block = EXPR{Block}(EXPR[], 0, 1:0, "")
     @catcherror ps @default ps parse_block(ps, block)
@@ -102,6 +82,5 @@ function parse_struct(ps::ParseState, mutable)
     T = mutable == TRUE ? Tokens.TYPE : Tokens.IMMUTABLE
     next(ps)
     ret = EXPR{mutable == TRUE ? Mutable : Struct}(EXPR[kw, sig, block, INSTANCE(ps)], "")
-
     return ret
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,24 +1,6 @@
 function AbstractTrees.printnode(io::IO, x::EXPR{T}) where T
     print(io, T, "  ", x.fullspan, " (", x.span, ")")
-    if isempty(x.defs)
-        print(io)
-    else
-        print(io, "  {", join((a.id for a in x.defs), ","), "}")
-    end
+    print(io)
 end
 Base.show(io::IO, x::EXPR) = AbstractTrees.print_tree(io, x, 3)
 
-
-function Base.show(io::IO, x::Scope{T}, indent = 0) where {T}
-    print(io, "  "^indent, "↘ ", T, " (", length(x.args), ") ")
-    println(io, "[", join(collect(a.id.val for a in x.args if a isa Variable), ", "), "]")
-    for a in x.args
-        if a isa Scope
-            show(io, a, indent + 1)
-        end
-    end
-end
-
-function Base.show(io::IO, x::Variable, indent = 0)
-    println(io, " "^indent, "Var → $(x.id)::$(x.t)")
-end

--- a/src/hints.jl
+++ b/src/hints.jl
@@ -92,49 +92,49 @@ function error_unexpected(ps, startbyte, tok)
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedInputEnd}(
             tok.startbyte:tok.endbyte, [], "Unexpected end of input"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected end of input")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unexpected end of input")
     elseif tok.kind == Tokens.COMMA
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedComma}(
             tok.startbyte:tok.endbyte, [], "Unexpected comma"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected comma")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unexpected comma")
     elseif tok.kind == Tokens.LPAREN
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLParen}(
             tok.startbyte:tok.endbyte, [], "Unexpected ("
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected (")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unexpected (")
     elseif tok.kind == Tokens.RPAREN
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRParen}(
             tok.startbyte:tok.endbyte, [], "Unexpected )"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected )")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unexpected )")
     elseif tok.kind == Tokens.LBRACE
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLBrace}(
             tok.startbyte:tok.endbyte, [], "Unexpected {"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected {")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unexpected {")
     elseif tok.kind == Tokens.RBRACE
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRBrace}(
             tok.startbyte:tok.endbyte, [], "Unexpected }"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected }")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unexpected }")
     elseif tok.kind == Tokens.LSQUARE
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLSquare}(
             tok.startbyte:tok.endbyte, [], "Unexpected ["
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected [")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unexpected [")
     elseif tok.kind == Tokens.RSQUARE
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRSquare}(
             tok.startbyte:tok.endbyte, [], "Unexpected ]"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected ]")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], "Unexpected ]")
     else
         error("Internal error")
     end

--- a/src/hints.jl
+++ b/src/hints.jl
@@ -76,8 +76,6 @@ end
 
 end
 
-# Formatting
-
 islbracket(t::Token) = t.kind == Tokens.LPAREN ||
                         t.kind == Tokens.LBRACE ||
                         t.kind == Tokens.LSQUARE
@@ -87,114 +85,6 @@ isrbracket(t::Token) = t.kind == Tokens.RPAREN ||
                         t.kind == Tokens.RSQUARE
 
 
-
-
-function format_op(ps, prec)
-    !ps.formatcheck && return
-    loc = ps.t.startbyte:ps.t.endbyte + 1
-    if (prec == ColonOp || prec == PowerOp || prec == DeclarationOp || prec == DotOp) && ps.t.kind != Tokens.ANON_FUNC && ps.t.kind != Tokens.PRIME
-        if ps.lws.kind != EmptyWS && ps.ws.kind != EmptyWS
-            diag = Diagnostic{Diagnostics.ExtraWS}(loc, Diagnostics.Action[Diagnostics.Deletion(ps.ws.startbyte:ps.nt.startbyte),Diagnostics.Deletion(ps.lws.startbyte:ps.t.startbyte)], "Unexpected white space around operator")
-            push!(ps.diagnostics, diag)
-        elseif ps.lws.kind != EmptyWS
-            diag = Diagnostic{Diagnostics.ExtraWS}(loc, Diagnostics.Action[Diagnostics.Deletion(ps.lws.startbyte:ps.t.startbyte)], "Unexpected white space around operator")
-            push!(ps.diagnostics, diag)
-        elseif ps.ws.kind != EmptyWS
-            diag = Diagnostic{Diagnostics.ExtraWS}(loc, Diagnostics.Action[Diagnostics.Deletion(ps.ws.startbyte:ps.nt.startbyte)], "Unexpected white space around operator")
-            push!(ps.diagnostics, diag)
-        end
-    elseif ps.t.kind == Tokens.PRIME
-        if ps.lws.kind != EmptyWS
-            diag = Diagnostic{Diagnostics.ExtraWS}(loc, Diagnostics.Action[Diagnostics.Deletion(ps.ws.startbyte:ps.nt.startbyte),Diagnostics.Deletion(ps.lws.startbyte:ps.t.startbyte)], "Unexpected white space around operator")
-            push!(ps.diagnostics, diag)
-        end
-    elseif ps.t.kind == Tokens.ISSUBTYPE || ps.t.kind == Tokens.DDDOT
-    else
-        if ps.lws.kind == EmptyWS && ps.ws.kind == EmptyWS
-            diag = Diagnostic{Diagnostics.MissingWS}(loc, Diagnostics.Action[Diagnostics.AddWS(ps.nt.startbyte:ps.nt.startbyte, 1),Diagnostics.AddWS(ps.t.startbyte:ps.t.startbyte, 1)], "Missing white space around operator")
-            push!(ps.diagnostics, diag)
-        elseif ps.lws.kind == EmptyWS
-            diag = Diagnostic{Diagnostics.MissingWS}(loc, Diagnostics.Action[Diagnostics.AddWS(ps.t.startbyte:ps.t.startbyte, 1)], "Missing white space around operator")
-            push!(ps.diagnostics, diag)
-        elseif ps.ws.kind == EmptyWS
-            diag = Diagnostic{Diagnostics.MissingWS}(loc, Diagnostics.Action[Diagnostics.AddWS(ps.nt.startbyte:ps.nt.startbyte, 1)], "Missing white space around operator")
-            push!(ps.diagnostics, diag)
-        end
-    end
-end
-
-function format_comma(ps)
-    !ps.formatcheck && return
-    if ps.lws.kind != EmptyWS && !(islbracket(ps.lt))
-        push!(ps.diagnostics, Diagnostic{Diagnostics.ExtraWS}(ps.t.startbyte + (0:1), [Diagnostics.Deletion(ps.lws.startbyte:ps.t.startbyte)], "Unexpected white space preceding comma"))
-    end
-    if ps.ws.kind == EmptyWS && !(isrbracket(ps.nt))
-        push!(ps.diagnostics, Diagnostic{Diagnostics.MissingWS}(ps.t.startbyte + (0:1), [Diagnostics.AddWS(ps.nt.startbyte:ps.nt.startbyte, 1)], "Missing white space following comma"))
-    end
-end
-
-function format_lbracket(ps)
-    !ps.formatcheck && return
-    if ps.ws.kind == WS
-        push!(ps.diagnostics, Diagnostic{Diagnostics.ExtraWS}(ps.t.startbyte + (0:1), [Diagnostics.Deletion(ps.ws.startbyte:ps.nt.startbyte)], "Unexpected white space following $(ps.t.val)"))
-    end
-end
-
-function format_rbracket(ps)
-    !ps.formatcheck && return
-    if ps.lws.kind == WS
-        push!(ps.diagnostics, Diagnostic{Diagnostics.ExtraWS}(ps.t.startbyte + (0:1), [Diagnostics.Deletion(ps.lws.startbyte:ps.t.startbyte)], "Unexpected white space preceding $(ps.t.val)"))
-    end
-end
-
-function format_indent(ps, start_col)
-    !ps.formatcheck && return
-    if (start_col > 0 && ps.nt.startpos[2] != start_col)
-        dindent = start_col - ps.nt.startpos[2]
-        if dindent > 0
-            push!(ps.diagnostics, Diagnostic{Diagnostics.MissingWS}(ps.nt.startbyte + (0:dindent), [Diagnostics.AddWS(ps.nt.startbyte:ps.nt.startbyte, dindent)], ""))
-        else
-            push!(ps.diagnostics, Diagnostic{Diagnostics.ExtraWS}(ps.nt.startbyte + (dindent + 1:0), [Diagnostics.Deletion(ps.nt.startbyte + (dindent:0))], ""))
-        end
-    end
-end
-
-function format_kw(ps)
-    !ps.formatcheck && return
-    if ps.ws.kind == WS
-        if length(ps.ws.val) > 1
-            push!(ps.diagnostics, Diagnostic{Diagnostics.ExtraWS}(ps.t.startbyte:ps.nt.startbyte, [Diagnostics.Deletion(ps.ws.startbyte + 1:ps.nt.startbyte)], ""))
-        end
-    end
-end
-
-function format_no_rws(ps)
-    !ps.formatcheck && return
-    if ps.ws.kind != EmptyWS
-        push!(ps.diagnostics, Diagnostic{Diagnostics.ExtraWS}(ps.t.startbyte:ps.nt.startbyte, [Diagnostics.Deletion(ps.ws.startbyte:ps.nt.startbyte)], ""))
-    end
-end
-
-function format_typename(ps, sig)
-    !ps.formatcheck && return
-#     id = get_id(sig)
-#     sig isa EXPR && return
-#     val = string(id.val)
-#     # Abitrary limit of 3 for uppercase acronym
-#     if islower(first(val)) || (length(val) > 3 && all(isupper, val))
-#         push!(ps.diagnostics, Diagnostic{Diagnostics.CamelCase}(start_loc + (1:sizeof(val))))
-#     end
-end
-
-function format_funcname(ps, id, offset)
-    !ps.formatcheck && return
-    # start_loc = ps.nt.startbyte - offset
-    # !(id isa Symbol) && return
-    # val = string(id)
-    # if !islower(val) #!all(islower(c) || isdigit(c) || c == '!' for c in val)
-    #     push!(ps.diagnostics, Diagnostic{Diagnostics.LowerCase}(start_loc + (1:sizeof(val))))
-    # end
-end
 
 function error_unexpected(ps, startbyte, tok)
     if tok.kind == Tokens.ENDMARKER

--- a/src/hints.jl
+++ b/src/hints.jl
@@ -202,49 +202,49 @@ function error_unexpected(ps, startbyte, tok)
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedInputEnd}(
             tok.startbyte:tok.endbyte, [], "Unexpected end of input"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected end of input")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected end of input")
     elseif tok.kind == Tokens.COMMA
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedComma}(
             tok.startbyte:tok.endbyte, [], "Unexpected comma"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected comma")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected comma")
     elseif tok.kind == Tokens.LPAREN
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLParen}(
             tok.startbyte:tok.endbyte, [], "Unexpected ("
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected (")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected (")
     elseif tok.kind == Tokens.RPAREN
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRParen}(
             tok.startbyte:tok.endbyte, [], "Unexpected )"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected )")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected )")
     elseif tok.kind == Tokens.LBRACE
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLBrace}(
             tok.startbyte:tok.endbyte, [], "Unexpected {"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected {")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected {")
     elseif tok.kind == Tokens.RBRACE
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRBrace}(
             tok.startbyte:tok.endbyte, [], "Unexpected }"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected }")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected }")
     elseif tok.kind == Tokens.LSQUARE
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedLSquare}(
             tok.startbyte:tok.endbyte, [], "Unexpected ["
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected [")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected [")
     elseif tok.kind == Tokens.RSQUARE
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedRSquare}(
             tok.startbyte:tok.endbyte, [], "Unexpected ]"
         ))
-        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, Variable[], "Unexpected ]")
+        return EXPR{ERROR}(EXPR[INSTANCE(ps)], 0, "Unexpected ]")
     else
         error("Internal error")
     end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -100,7 +100,7 @@ function INSTANCE(ps::ParseState)
         isoperator(ps.t) ? OPERATOR(ps) :
         ispunctuation(ps.t) ? PUNCTUATION(ps) :
         ps.t.kind == Tokens.SEMICOLON ? PUNCTUATION(ps) :
-        (ps.errored = true; EXPR{ERROR}(EXPR[], span, ""))
+        (ps.errored = true; EXPR{ERROR}(EXPR[], ""))
 end
 
 
@@ -125,7 +125,7 @@ mutable struct File
     ast::EXPR
     errors
 end
-File(path::String) = File([], [], path, EXPR{FileH}(EXPR[], 0, ""), [])
+File(path::String) = File([], [], path, EXPR{FileH}(EXPR[], ""), [])
 
 mutable struct Project
     path::String

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -23,8 +23,8 @@ function update_span!(x::EXPR)
     x.span = first(first(x.args).span):(x.fullspan - last(x.args).fullspan + last(last(x.args).span))
 end
 
-function EXPR{T}(args::Vector, defs::Vector, val::String) where {T}
-    ret = EXPR{T}(args, 0, 1:0, defs, val)
+function EXPR{T}(args::Vector, val::String) where {T}
+    ret = EXPR{T}(args, 0, 1:0, val)
     update_span!(ret)
     ret
 end

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -1,9 +1,3 @@
-mutable struct Variable
-    id
-    t
-    val
-end
-
 # Invariants:
 # if !isempty(e.args)
 #   e.fullspan == sum(x->x.fullspan, e.args)
@@ -17,7 +11,6 @@ mutable struct EXPR{T}
     # The range of bytes within the fullspan that constitute the actual expression,
     # excluding any leading/trailing whitespace or other trivia. 1-indexed
     span::UnitRange{Int}
-    defs::Vector{Variable}
     val::String
 end
 AbstractTrees.children(x::EXPR) = x.args
@@ -81,25 +74,25 @@ function LITERAL(ps::ParseState)
        ps.t.kind == Tokens.CMD || ps.t.kind == Tokens.TRIPLE_CMD
         return parse_string_or_cmd(ps)
     else
-        EXPR{LITERAL{ps.t.kind}}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), Variable[], ps.t.val)
+        EXPR{LITERAL{ps.t.kind}}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), ps.t.val)
     end
 end
 
-IDENTIFIER(ps::ParseState) = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), Variable[], ps.t.val)
+IDENTIFIER(ps::ParseState) = EXPR{IDENTIFIER}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), ps.t.val)
 
-OPERATOR(ps::ParseState) = EXPR{OPERATOR{precedence(ps.t),ps.t.kind,ps.dot}}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), Variable[], "")
+OPERATOR(ps::ParseState) = EXPR{OPERATOR{precedence(ps.t),ps.t.kind,ps.dot}}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), "")
 
-KEYWORD(ps::ParseState) = EXPR{KEYWORD{ps.t.kind}}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), Variable[], "")
+KEYWORD(ps::ParseState) = EXPR{KEYWORD{ps.t.kind}}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), "")
 
-PUNCTUATION(ps::ParseState) = EXPR{PUNCTUATION{ps.t.kind}}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), Variable[], "")
+PUNCTUATION(ps::ParseState) = EXPR{PUNCTUATION{ps.t.kind}}(EXPR[], ps.nt.startbyte - ps.t.startbyte, 1:(ps.t.endbyte-ps.t.startbyte+1), "")
 
 function INSTANCE(ps::ParseState)
     span = ps.nt.startbyte - ps.t.startbyte
-    ps.errored && return EXPR{ERROR}(EXPR[], span, 1:(ps.t.endbyte-ps.t.startbyte+1), Variable[], "")
+    ps.errored && return EXPR{ERROR}(EXPR[], span, 1:(ps.t.endbyte-ps.t.startbyte+1), "")
     if ps.t.kind == Tokens.ENDMARKER
         ps.errored = true
         push!(ps.diagnostics, Diagnostic{Diagnostics.UnexpectedInputEnd}(ps.t.startbyte + (0:0), [], "Unexpected end of input"))
-        return EXPR{ERROR}(EXPR[], span, 1:(ps.t.endbyte-ps.t.startbyte+1), Variable[], "Unexpected end of input")
+        return EXPR{ERROR}(EXPR[], span, 1:(ps.t.endbyte-ps.t.startbyte+1), "Unexpected end of input")
     end
     return isidentifier(ps.t) ? IDENTIFIER(ps) :
         isliteral(ps.t) ? LITERAL(ps) :
@@ -107,7 +100,7 @@ function INSTANCE(ps::ParseState)
         isoperator(ps.t) ? OPERATOR(ps) :
         ispunctuation(ps.t) ? PUNCTUATION(ps) :
         ps.t.kind == Tokens.SEMICOLON ? PUNCTUATION(ps) :
-        (ps.errored = true; EXPR{ERROR}(EXPR[], span, Variable[], ""))
+        (ps.errored = true; EXPR{ERROR}(EXPR[], span, ""))
 end
 
 
@@ -116,10 +109,10 @@ end
 # heads
 
 
-const TRUE = EXPR{LITERAL{Tokens.TRUE}}(EXPR[], 0, 1:0, Variable[], "")
-const FALSE = EXPR{LITERAL{Tokens.FALSE}}(EXPR[], 0, 1:0, Variable[], "")
-const NOTHING = EXPR{HEAD{:nothing}}(EXPR[], 0, 1:0, Variable[], "nothing")
-const GlobalRefDOC = EXPR{HEAD{:globalrefdoc}}(EXPR[], 0, 1:0, Variable[], "globalrefdoc")
+const TRUE = EXPR{LITERAL{Tokens.TRUE}}(EXPR[], 0, 1:0, "")
+const FALSE = EXPR{LITERAL{Tokens.FALSE}}(EXPR[], 0, 1:0, "")
+const NOTHING = EXPR{HEAD{:nothing}}(EXPR[], 0, 1:0, "nothing")
+const GlobalRefDOC = EXPR{HEAD{:globalrefdoc}}(EXPR[], 0, 1:0, "globalrefdoc")
 
 
 
@@ -132,7 +125,7 @@ mutable struct File
     ast::EXPR
     errors
 end
-File(path::String) = File([], [], path, EXPR{FileH}(EXPR[], 0, Variable[], ""), [])
+File(path::String) = File([], [], path, EXPR{FileH}(EXPR[], 0, ""), [])
 
 mutable struct Project
     path::String
@@ -141,7 +134,6 @@ end
 
 
 
-const NoVariable = Variable(NOTHING, NOTHING, NOTHING)
 
 abstract type Head end
 
@@ -215,4 +207,4 @@ abstract type Vcat <: Head end
 abstract type TypedVcat <: Head end
 abstract type Vect <: Head end
 
-Quotenode(x::EXPR) = EXPR{Quotenode}(EXPR[x], Variable[], "")
+Quotenode(x::EXPR) = EXPR{Quotenode}(EXPR[x], "")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -181,7 +181,7 @@ macro catcherror(ps, body)
     quote
         $(esc(body))
         if $(esc(ps)).errored
-            return EXPR{ERROR}(EXPR[INSTANCE($(esc(ps)))], 0, 0:-1, Variable[], "Unknown error")
+            return EXPR{ERROR}(EXPR[INSTANCE($(esc(ps)))], 0, 0:-1, "Unknown error")
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -526,18 +526,6 @@ function get_last_token(x::CSTParser.EXPR)
     end
 end
 
-function trailing_ws_length(x::CSTParser.EXPR{CSTParser.IDENTIFIER})
-    x.span - sizeof(x.val)
-end
-
-function trailing_ws_length(x::CSTParser.EXPR{P}) where P <: CSTParser.PUNCTUATION
-    x.span - 1
-end
-
-function trailing_ws_length(x::CSTParser.EXPR{K}) where K <: CSTParser.KEYWORD{T} where T
-    x.span - sizeof(string(T))
-end
-
-function trailing_ws_length(x::CSTParser.EXPR{K}) where K <: CSTParser.LITERAL{T} where T
-    x.span - sizeof(x.val)
+function trailing_ws_length(x::CSTParser.EXPR)
+    x.fullspan - length(x.span)
 end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -30,7 +30,7 @@ let diags = do_diag_test("a && && b")
 #  none:1:6 ERROR: Unexpected operator
 #  a && && b
 #       ^~~
-    @test diags[1] isa Diagnostic{UnexpectedOperator}
+    @test diags[1] isa Diagnostic{CSTParser.Diagnostics.UnexpectedOperator}
 end
 
 let diags = do_diag_test("print x")

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -671,29 +671,29 @@ end
     @test_broken "-1^a" |> test_expr
 end
 
-test_fsig_decl(str) = (x->x.id).(CSTParser._get_fsig(CSTParser.parse(str)).defs)
-@testset "func-sig variable declarations" begin
-    @test test_fsig_decl("f(x) = x") == [:x]
-    @test test_fsig_decl("""function f(x)
-        x
-    end""") == [:x]
+# test_fsig_decl(str) = (x->x.id).(CSTParser._get_fsig(CSTParser.parse(str)).defs)
+# @testset "func-sig variable declarations" begin
+#     @test test_fsig_decl("f(x) = x") == [:x]
+#     @test test_fsig_decl("""function f(x)
+#         x
+#     end""") == [:x]
 
-    @test test_fsig_decl("f{T}(x::T) = x") == [:T, :x]
-    @test test_fsig_decl("""function f{T}(x::T)
-        x
-    end""") == [:T, :x]
+#     @test test_fsig_decl("f{T}(x::T) = x") == [:T, :x]
+#     @test test_fsig_decl("""function f{T}(x::T)
+#         x
+#     end""") == [:T, :x]
 
-    @test test_fsig_decl("f(x::T) where T = x") == [:T, :x]
-    @test test_fsig_decl("""function f(x::T) where T
-        x
-    end""") == [:T, :x]
+#     @test test_fsig_decl("f(x::T) where T = x") == [:T, :x]
+#     @test test_fsig_decl("""function f(x::T) where T
+#         x
+#     end""") == [:T, :x]
 
 
-    @test test_fsig_decl("f(x::T{S}) where T where S = x") == [:T, :S, :x]
-    @test test_fsig_decl("""function f(x::T{S}) where T where S
-        x
-    end""") == [:T, :S, :x]
-end
+#     @test test_fsig_decl("f(x::T{S}) where T where S = x") == [:T, :S, :x]
+#     @test test_fsig_decl("""function f(x::T{S}) where T where S
+#         x
+#     end""") == [:T, :S, :x]
+# end
 
 @testset "Spans" begin
     CSTParser.parse(raw"""


### PR DESCRIPTION
I've moved formatting to https://github.com/ZacLN/DocumentFormat.jl, removed the `.defs` field and fixed a few things here and there.

@Keno, do you want to merge this here and then we have the whole refactor done in one?